### PR TITLE
Add live view prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,9 @@
 # Jolt
 
-To start your Phoenix server:
+# Development
 
   * Install dependencies with `mix deps.get`
   * Create and migrate your database with `mix ecto.setup`
   * Start Phoenix endpoint with `mix phx.server` or inside IEx with `iex -S mix phx.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
-
-Ready to run in production? Please [check our deployment guides](https://hexdocs.pm/phoenix/deployment.html).
-
-## Learn more
-
-  * Official website: https://www.phoenixframework.org/
-  * Guides: https://hexdocs.pm/phoenix/overview.html
-  * Docs: https://hexdocs.pm/phoenix
-  * Forum: https://elixirforum.com/c/phoenix-forum
-  * Source: https://github.com/phoenixframework/phoenix

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -99,6 +99,25 @@
   animation: 0.2s ease-out 0s normal forwards 1 fade-out-keys;
 }
 
+/*
+ * These are minimal examples for live view prototyping .
+ * Please delete accordingly when the code is gone.
+ * If you don't what this means, it means this code should dissapear.
+ * */
+.meter {
+    display: flex;
+    background-color: gray;
+    height: 40px;
+}
+.meter > span {
+    justify-content: center;
+    flex-direction: column;
+    whitespace: nowrap;
+    background: green;
+    font-weight: bold;
+    transition: width 500ms ease;
+}
+
 @keyframes fade-in-scale-keys{
   0% { scale: 0.95; opacity: 0; }
   100% { scale: 1.0; opacity: 1; }

--- a/lib/jolt/application.ex
+++ b/lib/jolt/application.ex
@@ -1,6 +1,4 @@
 defmodule Jolt.Application do
-  # See https://hexdocs.pm/elixir/Application.html
-  # for more information on OTP Applications
   @moduledoc false
 
   use Application
@@ -8,26 +6,18 @@ defmodule Jolt.Application do
   @impl true
   def start(_type, _args) do
     children = [
-      # Start the Ecto repository
       Jolt.Repo,
-      # Start the Telemetry supervisor
       JoltWeb.Telemetry,
-      # Start the PubSub system
       {Phoenix.PubSub, name: Jolt.PubSub},
-      # Start the Endpoint (http/https)
       JoltWeb.Endpoint
       # Start a worker by calling: Jolt.Worker.start_link(arg)
       # {Jolt.Worker, arg}
     ]
 
-    # See https://hexdocs.pm/elixir/Supervisor.html
-    # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Jolt.Supervisor]
     Supervisor.start_link(children, opts)
   end
 
-  # Tell Phoenix to update the endpoint configuration
-  # whenever the application is updated.
   @impl true
   def config_change(changed, _new, removed) do
     JoltWeb.Endpoint.config_change(changed, removed)

--- a/lib/jolt/mailer.ex
+++ b/lib/jolt/mailer.ex
@@ -1,3 +1,0 @@
-defmodule Jolt.Mailer do
-  use Swoosh.Mailer, otp_app: :jolt
-end

--- a/lib/jolt_web/live/counter_live.ex
+++ b/lib/jolt_web/live/counter_live.ex
@@ -1,0 +1,42 @@
+defmodule JoltWeb.CounterLive do
+  use JoltWeb, :live_view
+
+  @topic "counter"
+
+  def render(assigns) do
+    ~L"""
+    <h1>Counter</h1>
+    <div>
+      <div class="meter">
+        <span style="width: <%= @amount %>%">
+          <%= @amount %>
+        </span>
+      </div>
+
+      <button phx-click="down">-</button>
+      <button phx-click="up">+</button>
+    </div>
+    """
+  end
+
+  def mount(_params, _session, socket) do
+    JoltWeb.Endpoint.subscribe(@topic)
+    {:ok, assign(socket, :amount, 0)}
+  end
+
+  def handle_info(%{topic: @topic, payload: amount}, socket) do
+    {:noreply, assign(socket, :amount, amount)}
+  end
+
+  def handle_event("up", _, socket) do
+    amount = socket.assigns.amount + 1
+    JoltWeb.Endpoint.broadcast_from(self(), @topic, "donate_event", amount)
+    {:noreply, assign(socket, :amount, amount)}
+  end
+
+  def handle_event("down", _, socket) do
+    amount = socket.assigns.amount - 1
+    JoltWeb.Endpoint.broadcast_from(self(), @topic, "donate_event", amount)
+    {:noreply, assign(socket, :amount, amount)}
+  end
+end

--- a/lib/jolt_web/router.ex
+++ b/lib/jolt_web/router.ex
@@ -18,12 +18,8 @@ defmodule JoltWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :index
+    live "/counter", CounterLive
   end
-
-  # Other scopes may use custom stacks.
-  # scope "/api", JoltWeb do
-  #   pipe_through :api
-  # end
 
   # Enables LiveDashboard only for development
   #
@@ -39,18 +35,6 @@ defmodule JoltWeb.Router do
       pipe_through :browser
 
       live_dashboard "/dashboard", metrics: JoltWeb.Telemetry
-    end
-  end
-
-  # Enables the Swoosh mailbox preview in development.
-  #
-  # Note that preview only shows emails that were sent by the same
-  # node running the Phoenix server.
-  if Mix.env() == :dev do
-    scope "/dev" do
-      pipe_through :browser
-
-      forward "/mailbox", Plug.Swoosh.MailboxPreview
     end
   end
 end

--- a/lib/jolt_web/templates/layout/root.html.heex
+++ b/lib/jolt_web/templates/layout/root.html.heex
@@ -10,21 +10,6 @@
     <script defer phx-track-static type="text/javascript" src={Routes.static_path(@conn, "/assets/app.js")}></script>
   </head>
   <body>
-    <header>
-      <section class="container">
-        <nav>
-          <ul>
-            <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li>
-            <%= if function_exported?(Routes, :live_dashboard_path, 2) do %>
-              <li><%= link "LiveDashboard", to: Routes.live_dashboard_path(@conn, :home) %></li>
-            <% end %>
-          </ul>
-        </nav>
-        <a href="https://phoenixframework.org/" class="phx-logo">
-          <img src={Routes.static_path(@conn, "/images/phoenix.png")} alt="Phoenix Framework Logo"/>
-        </a>
-      </section>
-    </header>
     <%= @inner_content %>
   </body>
 </html>

--- a/lib/jolt_web/views/layout_view.ex
+++ b/lib/jolt_web/views/layout_view.ex
@@ -1,7 +1,5 @@
 defmodule JoltWeb.LayoutView do
   use JoltWeb, :view
 
-  # Phoenix LiveDashboard is available only in development by default,
-  # so we instruct Elixir to not warn if the dashboard route is missing.
   @compile {:no_warn_undefined, {Routes, :live_dashboard_path, 2}}
 end


### PR DESCRIPTION
This is a small prototype of using live view. It demonstrates live view
using a small counter and a width. The counter information will be
broadcast back to all clients.

The intent of this is to grow to support the messaging aspects of the
application. As messages are stored, they will be shared back to their
corresponding subscriptions.